### PR TITLE
Add IStringLocalizer support

### DIFF
--- a/FormTest.Application/DTOs/LoginUserDto.cs
+++ b/FormTest.Application/DTOs/LoginUserDto.cs
@@ -1,15 +1,16 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using FormTest.Web;
 
 namespace FormTest.Application.DTOs
 {
     public class LoginUserDto
     {
 
-        [Required(ErrorMessage = "ایمیل الزامی است")]
-        [EmailAddress(ErrorMessage = "ایمیل وارد شده معتبر نیست")]
+        [Required(ErrorMessageResourceType = typeof(SharedResource), ErrorMessageResourceName = "EmailRequired")]
+        [EmailAddress(ErrorMessageResourceType = typeof(SharedResource), ErrorMessageResourceName = "InvalidEmail")]
         public string Email { get; set; }
 
-        [Required(ErrorMessage = "رمز عبور الزامی است")]
+        [Required(ErrorMessageResourceType = typeof(SharedResource), ErrorMessageResourceName = "PasswordRequired")]
         public string Password { get; set; }
     }
 }

--- a/FormTest.Core/Application/DTOs/LoginUserDto.cs
+++ b/FormTest.Core/Application/DTOs/LoginUserDto.cs
@@ -1,15 +1,16 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using FormTest.Web;
 
 namespace FormTest.Core.Application.DTOs
 {
     public class LoginUserDto
     {
 
-        [Required(ErrorMessage = "ایمیل الزامی است")]
-        [EmailAddress(ErrorMessage = "ایمیل وارد شده معتبر نیست")]
+        [Required(ErrorMessageResourceType = typeof(SharedResource), ErrorMessageResourceName = "EmailRequired")]
+        [EmailAddress(ErrorMessageResourceType = typeof(SharedResource), ErrorMessageResourceName = "InvalidEmail")]
         public string Email { get; set; }
 
-        [Required(ErrorMessage = "رمز عبور الزامی است")]
+        [Required(ErrorMessageResourceType = typeof(SharedResource), ErrorMessageResourceName = "PasswordRequired")]
         public string Password { get; set; }
     }
 }

--- a/FormTest.Core/Application/DTOs/RegisterUserDto.cs
+++ b/FormTest.Core/Application/DTOs/RegisterUserDto.cs
@@ -1,18 +1,19 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using FormTest.Web;
 
 namespace FormTest.Core.Application.DTOs
 {
     public class RegisterUserDto
     {
-        [Required(ErrorMessage = "وارد کردن نام الزامی است")]
+        [Required(ErrorMessageResourceType = typeof(SharedResource), ErrorMessageResourceName = "NameRequired")]
         public string Name { get; set; }
 
-        [Required(ErrorMessage = "وارد کردن ایمیل الزامی است")]
-        [EmailAddress(ErrorMessage = "ایمیل وارد شده معتبر نیست")]
+        [Required(ErrorMessageResourceType = typeof(SharedResource), ErrorMessageResourceName = "EmailRequired")]
+        [EmailAddress(ErrorMessageResourceType = typeof(SharedResource), ErrorMessageResourceName = "InvalidEmail")]
         public string Email { get; set; }
 
-        [Required(ErrorMessage = "وارد کردن رمز عبور الزامی است")]
-        [MinLength(6, ErrorMessage = "رمز عبور باید حداقل ۶ کاراکتر باشد")]
+        [Required(ErrorMessageResourceType = typeof(SharedResource), ErrorMessageResourceName = "PasswordRequired")]
+        [MinLength(6, ErrorMessageResourceType = typeof(SharedResource), ErrorMessageResourceName = "PasswordMinLength")]
         public string Password { get; set; }
     }
 }

--- a/FormTest.Web/Controllers/AccountController.cs
+++ b/FormTest.Web/Controllers/AccountController.cs
@@ -3,6 +3,8 @@ using FormTest.Core.Domain.Interfaces;
 using FormTest.Core.Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
 using FormTest.Core.Application.Contracts;
+using Microsoft.Extensions.Localization;
+using FormTest.Web;
 
 
 namespace FormTest.Web.Controllers
@@ -11,10 +13,12 @@ namespace FormTest.Web.Controllers
     {
 
         private readonly IUserService _UserService;
+        private readonly IStringLocalizer<SharedResource> _localizer;
 
-        public AccountController(IUserService UserService)
+        public AccountController(IUserService UserService, IStringLocalizer<SharedResource> localizer)
         {
             _UserService = UserService;
+            _localizer = localizer;
         }
 
         // GET: /Account/Register
@@ -32,7 +36,7 @@ namespace FormTest.Web.Controllers
             }
             if (_UserService.IsEmailTaken(dto.Email))
             {
-                ModelState.AddModelError("Email", "ایمیل قبلاً ثبت شده است.");
+                ModelState.AddModelError("Email", _localizer["EmailAlreadyRegistered"]);
                 return View(dto);
             }
 
@@ -56,15 +60,15 @@ namespace FormTest.Web.Controllers
             var user = _UserService.Login(dto);
             if (user == null)
             {
-                ViewBag.ErrorMessage = "کاربری با این مشخصات یافت نشد";
+                ViewBag.ErrorMessage = _localizer["UserNotFound"];
                 return View(dto);
             }
             if (!user.IsApproved)
             {
-                ViewBag.ErrorMessage = "حساب کاربری شما هنوز تأیید نشده است";
+                ViewBag.ErrorMessage = _localizer["UserNotApproved"];
                 return View(dto);
             }
-            ViewBag.Message = $"خوش آمدید {user.Name}";
+            ViewBag.Message = string.Format(_localizer["WelcomeUser"], user.Name);
             HttpContext.Session.SetString("UserName", user.Name);
             HttpContext.Session.SetString("UserEmail", user.Email);
             HttpContext.Session.SetString("UserRole", user.Role.ToString());

--- a/FormTest.Web/HostingExtensions.cs
+++ b/FormTest.Web/HostingExtensions.cs
@@ -10,7 +10,10 @@ public static class HostingExtensions
 {
     public static void ConfigureServices(this WebApplicationBuilder builder)
     {
-        builder.Services.AddControllersWithViews();
+        builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
+        builder.Services.AddControllersWithViews()
+            .AddViewLocalization()
+            .AddDataAnnotationsLocalization();
 
         builder.Services.AddSession();
 
@@ -37,6 +40,13 @@ public static class HostingExtensions
         app.UseStaticFiles();
 
         app.UseRouting();
+        var supportedCultures = new[] { new System.Globalization.CultureInfo("fa"), new System.Globalization.CultureInfo("en") };
+        app.UseRequestLocalization(new Microsoft.AspNetCore.Localization.RequestLocalizationOptions
+        {
+            DefaultRequestCulture = new Microsoft.AspNetCore.Localization.RequestCulture("fa"),
+            SupportedCultures = supportedCultures,
+            SupportedUICultures = supportedCultures
+        });
         app.UseSession();
         app.UseAuthorization();
 

--- a/FormTest.Web/Resources/SharedResource.fa.resx
+++ b/FormTest.Web/Resources/SharedResource.fa.resx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, ...</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, ...</value>
+  </resheader>
+  <data name="EmailAlreadyRegistered" xml:space="preserve">
+    <value>ایمیل قبلاً ثبت شده است.</value>
+  </data>
+  <data name="UserNotFound" xml:space="preserve">
+    <value>کاربری با این مشخصات یافت نشد</value>
+  </data>
+  <data name="UserNotApproved" xml:space="preserve">
+    <value>حساب کاربری شما هنوز تأیید نشده است</value>
+  </data>
+  <data name="NameRequired" xml:space="preserve">
+    <value>وارد کردن نام الزامی است</value>
+  </data>
+  <data name="EmailRequired" xml:space="preserve">
+    <value>وارد کردن ایمیل الزامی است</value>
+  </data>
+  <data name="InvalidEmail" xml:space="preserve">
+    <value>ایمیل وارد شده معتبر نیست</value>
+  </data>
+  <data name="PasswordRequired" xml:space="preserve">
+    <value>وارد کردن رمز عبور الزامی است</value>
+  </data>
+  <data name="PasswordMinLength" xml:space="preserve">
+    <value>رمز عبور باید حداقل ۶ کاراکتر باشد</value>
+  </data>
+  <data name="WelcomeUser" xml:space="preserve">
+    <value>خوش آمدید {0}</value>
+  </data>
+</root>

--- a/FormTest.Web/SharedResource.cs
+++ b/FormTest.Web/SharedResource.cs
@@ -1,0 +1,6 @@
+namespace FormTest.Web
+{
+    public class SharedResource
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- add SharedResource and Persian resource file
- use localization for validation messages and controller strings
- configure localization services and request culture

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684142a420188325bb65f7d6827f70b7