### PR TITLE
Add Farsi translations

### DIFF
--- a/Localization/Resources/SharedResource.fa.resx
+++ b/Localization/Resources/SharedResource.fa.resx
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>2.0</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="EmailAlreadyRegistered" xml:space="preserve">
+    <value>ایمیل قبلاً ثبت شده است</value>
+  </data>
+	<data name="UserNotFound" xml:space="preserve">
+    <value>کاربر پیدا نشد</value>
+  </data>
+	<data name="UserNotApproved" xml:space="preserve">
+    <value>حساب شما هنوز تأیید نشده است</value>
+  </data>
+	<data name="NameRequired" xml:space="preserve">
+    <value>نام الزامی است</value>
+  </data>
+	<data name="EmailRequired" xml:space="preserve">
+    <value>ایمیل الزامی است</value>
+  </data>
+	<data name="InvalidEmail" xml:space="preserve">
+    <value>ایمیل نامعتبر است</value>
+  </data>
+	<data name="PasswordRequired" xml:space="preserve">
+    <value>رمز عبور الزامی است</value>
+  </data>
+	<data name="PasswordMinLength" xml:space="preserve">
+    <value>رمز عبور باید حداقل 6 کاراکتر باشد</value>
+  </data>
+	<data name="WelcomeUser" xml:space="preserve">
+    <value>خوش آمدید {0}</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- add `SharedResource.fa.resx` so validation messages appear in Farsi

## Testing
- `dotnet build FormTest.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484dc720e48325ac1075d94f6315a4